### PR TITLE
Remove last slash from cmake command

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ros-noetic-gazebo-plugins
 	pkgdesc = ROS - Robot-independent Gazebo plugins for sensors, motors and dynamic reconfigurable components.
 	pkgver = 2.9.2
-	pkgrel = 3
+	pkgrel = 4
 	url = https://wiki.ros.org/gazebo_plugins
 	arch = i686
 	arch = x86_64

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -83,7 +83,7 @@ build() {
         -DCATKIN_BUILD_BINARY_PACKAGE=ON \
         -DCMAKE_INSTALL_PREFIX=/opt/ros/noetic \
         -DPYTHON_EXECUTABLE=/usr/bin/python \
-        -DSETUPTOOLS_DEB_LAYOUT=OFF \
+        -DSETUPTOOLS_DEB_LAYOUT=OFF
   make
 }
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@ url='https://wiki.ros.org/gazebo_plugins'
 pkgname='ros-noetic-gazebo-plugins'
 pkgver='2.9.2'
 arch=('i686' 'x86_64' 'aarch64' 'armv7h' 'armv6h')
-pkgrel=3
+pkgrel=4
 license=('BSD, Apache 2.0')
 
 ros_makedepends=(ros-noetic-diagnostic-updater


### PR DESCRIPTION
The slash on line 86 was causing the make command to be interpret as a directory for the cmake command, and thus causing a build failure.